### PR TITLE
BUG: _qmc.py::_random_oa_lhs produces correlated samples

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1494,7 +1494,8 @@ class LatinHypercube(QMCEngine):
         for j in range(n_col):
             perms = self.rng.permutation(p)
             oa_sample_[:, j] = perms[oa_sample[:, j]]
-
+        
+        oa_sample = oa_sample_
         # following is making a scrambled OA into an OA-LHS
         oa_lhs_sample = np.zeros(shape=(n_row, n_col))
         lhs_engine = LatinHypercube(d=1, scramble=self.scramble, strength=1,
@@ -1504,8 +1505,6 @@ class LatinHypercube(QMCEngine):
                 idx = oa_sample[:, j] == k
                 lhs = lhs_engine.random(p).flatten()
                 oa_lhs_sample[:, j][idx] = lhs + oa_sample[:, j][idx]
-
-                lhs_engine = lhs_engine.reset()
 
         oa_lhs_sample /= p
 


### PR DESCRIPTION

The variable `oa_sample_` scambles the orthogonal array but is not being used. As a result the sample outputs are highly correlated in higher dimensions and with large samples. 

lhs_engine.reset() causes identical LHS sampling to be applied in each orthogonal subsection. This creates patterns to arise when observing at larger scales and may result in an aliasing affect. Removing it should improve the random properties of the LHS sampling.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

The orthogonal arrays were highly correlated across higher dimensions. 

#### Additional information
<!--Any additional information you think is important.-->

Minimum code example. Three dimensional sampling, colored by the 3rd dimension:
```
from scipy.stats import qmc
import matplotlib.pyplot as plt

sampler = qmc.LatinHypercube(d=3, strength=2, scramble=True, seed=1)
sample = sampler.random(n=529)

plt.scatter(sample[:,0], sample[:,1], c=sample[:,2])
plt.show()

```
Result before fix:
![LHS_OA_Test_before_fix](https://github.com/pwcnorthrop/scipy/assets/15019244/6c1a248d-29b0-4562-b18d-7be8a38c7e79)

Result after fix:
![LHS_OA_Test_after_fix](https://github.com/pwcnorthrop/scipy/assets/15019244/61b9da40-6844-48d0-8338-8ca7491e9f4d)
